### PR TITLE
Don't filter databases by app id and other small changes

### DIFF
--- a/crates/cloud/src/client.rs
+++ b/crates/cloud/src/client.rs
@@ -445,18 +445,22 @@ impl Client {
 
     pub async fn list_links(
         &self,
-        _app_id: Option<Uuid>,
-    ) -> anyhow::Result<Vec<crate::mocks::Link>> {
+        app_id: Option<Uuid>,
+    ) -> anyhow::Result<Vec<crate::mocks::DatabaseLink>> {
+        let _ = app_id;
         Ok(crate::mocks::mock_links_list())
     }
 
-    // TODO: ideally returns Some(prev dbname) if updated otherwise None
-    pub async fn create_link(&self, _link: &AppLabel, _database: &str) -> anyhow::Result<()> {
+    /// Do we want to future proof this? Right now this assumes all links are to databases
+    /// but that might not be true in the future.
+    pub async fn create_link(&self, link: &crate::mocks::DatabaseLink) -> anyhow::Result<()> {
+        let _ = link;
         println!("entered create_link");
         Ok(())
     }
 
-    pub async fn remove_link(&self, _link: &AppLabel, _database: &str) -> anyhow::Result<()> {
+    pub async fn remove_link(&self, link: &crate::mocks::DatabaseLink) -> anyhow::Result<()> {
+        let _ = link;
         println!("entered remove_link");
         Ok(())
     }

--- a/crates/cloud/src/client.rs
+++ b/crates/cloud/src/client.rs
@@ -429,10 +429,7 @@ impl Client {
             .map_err(format_response_error)
     }
 
-    pub async fn get_databases(
-        &self,
-        _app_id: Option<Uuid>,
-    ) -> anyhow::Result<Vec<crate::mocks::Database>> {
+    pub async fn get_databases(&self) -> anyhow::Result<Vec<crate::mocks::Database>> {
         Ok(crate::mocks::mock_databases_list())
     }
 

--- a/crates/cloud/src/client.rs
+++ b/crates/cloud/src/client.rs
@@ -433,11 +433,11 @@ impl Client {
         Ok(crate::mocks::mock_databases_list())
     }
 
-    pub async fn get_database(
-        &self,
-        _name: &str,
-    ) -> anyhow::Result<Option<crate::mocks::Database>> {
-        Ok(None)
+    pub async fn get_database(&self, name: &str) -> anyhow::Result<Option<crate::mocks::Database>> {
+        Ok(Some(crate::mocks::Database {
+            name: name.to_owned(),
+            links: vec![],
+        }))
     }
 
     pub async fn list_links(

--- a/crates/cloud/src/mocks.rs
+++ b/crates/cloud/src/mocks.rs
@@ -1,5 +1,6 @@
 use uuid::Uuid;
 
+/// A label representing a resource for a given app
 #[derive(Clone, PartialEq)]
 pub struct AppLabel {
     pub label: String,
@@ -8,13 +9,13 @@ pub struct AppLabel {
 }
 
 #[derive(Clone, PartialEq)]
-pub struct Link {
+pub struct DatabaseLink {
     pub app_label: AppLabel,
     pub database: String,
 }
 
-impl Link {
-    fn new(app_label: AppLabel, database: String) -> Self {
+impl DatabaseLink {
+    pub fn new(app_label: AppLabel, database: String) -> Self {
         Self {
             app_label,
             database,
@@ -43,8 +44,9 @@ impl Database {
     }
 }
 
+// TODO: remove all of this mocking code
 impl AppLabel {
-    pub fn new(label: String) -> Self {
+    fn new(label: String) -> Self {
         let app_id = Uuid::new_v4();
         let app_name = format!("myapp-{}", app_id.as_simple());
         AppLabel {
@@ -68,9 +70,9 @@ pub fn mock_databases_list() -> Vec<Database> {
     ]
 }
 
-pub fn mock_links_list() -> Vec<Link> {
+pub fn mock_links_list() -> Vec<DatabaseLink> {
     vec![
-        Link::new(AppLabel::new("foo".to_string()), "db1".to_string()),
-        Link::new(AppLabel::new("yee".to_string()), "db2".to_string()),
+        DatabaseLink::new(AppLabel::new("foo".to_string()), "db1".to_string()),
+        DatabaseLink::new(AppLabel::new("yee".to_string()), "db2".to_string()),
     ]
 }

--- a/crates/cloud/src/mocks.rs
+++ b/crates/cloud/src/mocks.rs
@@ -21,6 +21,10 @@ impl DatabaseLink {
             database,
         }
     }
+
+    pub fn has_label(&self, label: &str) -> bool {
+        self.app_label.label == label
+    }
 }
 
 pub struct Database {

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -10,6 +10,7 @@ use cloud::{
 /// Manage how apps and resources are linked together
 #[derive(Parser, Debug)]
 pub enum LinkCommand {
+    /// Link an app to a sqlite database
     Sqlite(SqliteLinkCommand),
 }
 
@@ -17,10 +18,13 @@ pub enum LinkCommand {
 pub struct SqliteLinkCommand {
     #[clap(flatten)]
     common: CommonArgs,
+    /// The name by which the application will refer to the database
     // TODO: validate label syntax
     label: String,
     #[clap(short = 'a', long = "app")]
+    /// The app that will be using the database
     app: String,
+    /// The database that the app will be referring to by the label
     #[clap(short = 'd', long = "database")]
     database: String,
 }
@@ -62,11 +66,10 @@ impl SqliteLinkCommand {
             .await
             .context("Problem listing links")?;
         let existing_link_for_database = links_for_app.iter().find(|l| l.database == self.database);
-        let existing_link_with_name = links_for_app
-            .iter()
-            .find(|l| l.app_label.label == self.label);
-        match (existing_link_for_database, existing_link_with_name) {
+        let existing_link_with_label = links_for_app.iter().find(|l| l.has_label(&self.label));
+        match (existing_link_for_database, existing_link_with_label) {
             (Some(link), _) => {
+                // TODO: is this so bad? Why not allow linking an app to a database through multiple labels?
                 anyhow::bail!(
                     r#"Database "{}" is already linked to app "{}" with label "{}""#,
                     link.database,

--- a/src/commands/sqlite.rs
+++ b/src/commands/sqlite.rs
@@ -87,7 +87,7 @@ impl SqliteCommand {
         match self {
             Self::Delete(cmd) => {
                 let client = create_cloud_client(cmd.common.deployment_env_id.as_deref()).await?;
-                let list = CloudClient::get_databases(&client, None)
+                let list = CloudClient::get_databases(&client)
                     .await
                     .context("Problem fetching databases")?;
                 let found = list.iter().find(|d| d.name == cmd.name);
@@ -108,7 +108,7 @@ impl SqliteCommand {
             }
             Self::Execute(cmd) => {
                 let client = create_cloud_client(cmd.common.deployment_env_id.as_deref()).await?;
-                let list = CloudClient::get_databases(&client, None)
+                let list = CloudClient::get_databases(&client)
                     .await
                     .context("Problem fetching databases")?;
                 if !list.iter().any(|d| d.name == cmd.name) {
@@ -126,7 +126,7 @@ impl SqliteCommand {
             }
             Self::List(cmd) => {
                 let client = create_cloud_client(cmd.common.deployment_env_id.as_deref()).await?;
-                let list = CloudClient::get_databases(&client, None)
+                let list = CloudClient::get_databases(&client)
                     .await
                     .context("Problem listing databases")?;
                 print_databases(list, cmd.app, cmd.database);


### PR DESCRIPTION
Another mostly refactoring PR. The changes included:
* Not filtering the call to `get_databases` by app id which we were doing in  `get_database_selection_for_existing_app`. The existing app should be able to link to a database that is not already linked to the app. 
* Added some doc comments so that the help output in the link cli is well documented
* Some small renames of local variables and enums to be more explicit
* Moved the mapping from database to database name down the stack so that we only do that when we're sure we need to.
* Added some helper methods on the various models.